### PR TITLE
Add support for multiple ZRAM files

### DIFF
--- a/res/layout/activity_main.xml
+++ b/res/layout/activity_main.xml
@@ -32,6 +32,12 @@
         android:layout_height="wrap_content"
         android:id="@+id/zram_mem_used_total"
         android:text="@string/zram_mem_used_total" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/zram_number_of_files"
+        android:text="@string/zram_number_of_files" />
     
     <ProgressBar
     	android:id="@+id/zram_compression_ratio_bar"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -26,6 +26,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
     <string name="zram_compressed_data_size">ZRAM Compressed Data Size:</string>
 	<string name="zram_original_data_size">ZRAM Original Data Size:</string>
     <string name="zram_mem_used_total">ZRAM Total Memory Used:</string>
+    <string name="zram_number_of_files">ZRAM Number Of Files:</string>
     
     <string name="zram_compression_ratio">ZRAM Compression Ratio:</string>
     <string name="zram_used_ratio">ZRAM Used Ratio:</string>

--- a/src/id/co/ptskp/android/zs/MainActivity.java
+++ b/src/id/co/ptskp/android/zs/MainActivity.java
@@ -132,7 +132,14 @@ public class MainActivity extends Activity {
         			+ nf.format(zram.getMemUsedTotal())
         			+ " bytes"
     			);
-    		
+
+    		TextView tvZramNumberOfFiles = (TextView) findViewById(R.id.zram_number_of_files);
+    		tvZramNumberOfFiles.setText(
+        			getResources().getString(R.string.zram_number_of_files) 
+        			+ " "
+        			+ nf.format(zram.getNumberOfFiles())
+    			);
+
     		final int compressionRatio = Math.round(zram.getCompressionRatio() * 100);
     		ProgressBar pbZramCompressionRatio = (ProgressBar) findViewById(R.id.zram_compression_ratio_bar);
     		pbZramCompressionRatio.setProgress(compressionRatio);


### PR DESCRIPTION
Many ROMs/mods for multi-core devices use more than one ZRAM file. These changes allow to gather information about multiple ZRAM files and also displays ZRAM file count.

It is recommended to use multiple ZRAM files on multi-core systems prior to Kernel 3.15.
